### PR TITLE
Add admin dashboard restricted to admins

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Admin\DashboardStatistics;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): View
+    {
+        $statistics = DashboardStatistics::collect();
+        $users = User::query()
+            ->select(['id', 'name', 'email', 'role', 'created_at'])
+            ->withCount(['missions', 'taskLists'])
+            ->orderByDesc('created_at')
+            ->get();
+
+        return view('admin.dashboard', [
+            'statistics' => $statistics,
+            'users' => $users,
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->isAdmin()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Admin/DashboardStatistics.php
+++ b/app/Models/Admin/DashboardStatistics.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models\Admin;
+
+use App\Models\Mission;
+use App\Models\TaskList;
+use App\Models\User;
+
+final class DashboardStatistics
+{
+    public function __construct(
+        public readonly int $usersCount,
+        public readonly int $missionsCount,
+        public readonly int $listsCount,
+    ) {
+    }
+
+    public static function collect(): self
+    {
+        return new self(
+            usersCount: User::count(),
+            missionsCount: Mission::count(),
+            listsCount: TaskList::count(),
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function toArray(): array
+    {
+        return [
+            'usersCount' => $this->usersCount,
+            'missionsCount' => $this->missionsCount,
+            'listsCount' => $this->listsCount,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Models\Concerns\HasFeatureFlags;
+use App\Models\Mission;
+use App\Models\TaskList;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -25,6 +27,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -60,5 +63,20 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    public function missions()
+    {
+        return $this->hasMany(Mission::class);
+    }
+
+    public function taskLists()
+    {
+        return $this->hasMany(TaskList::class, 'user_id');
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === 'admin';
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureUserIsAdmin;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,7 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'admin' => EnsureUserIsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'user',
         ];
     }
 
@@ -39,6 +40,13 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'admin',
         ]);
     }
 }

--- a/database/migrations/2025_10_26_000001_add_role_to_users_table.php
+++ b/database/migrations/2025_10_26_000001_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('role')->default('user')->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,110 @@
+{{-- Administrative dashboard displaying platform metrics. --}}
+@extends('layouts.app')
+
+@section('title', __('Admin Dashboard'))
+
+@section('content')
+    <div class="flex min-h-screen bg-zinc-100 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+        @include('app.shared.navigation')
+
+        <main class="flex-1 px-4 py-12 sm:px-6 lg:px-10">
+            <div class="mx-auto max-w-6xl space-y-10">
+                <header class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h1 class="text-3xl font-semibold tracking-tight">{{ __('Admin Dashboard') }}</h1>
+                        <p class="mt-2 max-w-2xl text-sm text-zinc-500 dark:text-zinc-400">
+                            {{ __('Acompanhe o resumo da plataforma, incluindo usuários cadastrados, tarefas e listas ativas.') }}
+                        </p>
+                    </div>
+                </header>
+
+                <section>
+                    <h2 class="text-lg font-medium text-zinc-900 dark:text-zinc-100">{{ __('Resumo Rápido') }}</h2>
+                    <dl class="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        <div class="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-900">
+                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Usuários cadastrados') }}</dt>
+                            <dd class="mt-3 text-3xl font-semibold text-emerald-600 dark:text-emerald-400">
+                                {{ number_format($statistics->usersCount) }}
+                            </dd>
+                        </div>
+
+                        <div class="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-900">
+                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Total de tarefas') }}</dt>
+                            <dd class="mt-3 text-3xl font-semibold text-sky-600 dark:text-sky-400">
+                                {{ number_format($statistics->missionsCount) }}
+                            </dd>
+                        </div>
+
+                        <div class="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-900">
+                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Total de listas') }}</dt>
+                            <dd class="mt-3 text-3xl font-semibold text-amber-600 dark:text-amber-400">
+                                {{ number_format($statistics->listsCount) }}
+                            </dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section>
+                    <div class="flex items-center justify-between gap-3">
+                        <h2 class="text-lg font-medium text-zinc-900 dark:text-zinc-100">{{ __('Usuários cadastrados') }}</h2>
+                        <p class="text-xs text-zinc-500 dark:text-zinc-400">{{ trans_choice('{0}Nenhum usuário|{1}1 usuário|[2,*]:count usuários', $statistics->usersCount, ['count' => $statistics->usersCount]) }}</p>
+                    </div>
+
+                    <div class="mt-4 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+                        <table class="min-w-full divide-y divide-zinc-200 dark:divide-zinc-700">
+                            <thead class="bg-zinc-50 dark:bg-zinc-800">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                                        {{ __('Nome') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                                        {{ __('E-mail') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-center text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                                        {{ __('Tarefas') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-center text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                                        {{ __('Listas') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                                        {{ __('Cadastro') }}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-zinc-200 dark:divide-zinc-800">
+                                @forelse ($users as $user)
+                                    <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/80">
+                                        <td class="px-6 py-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                            {{ $user->name }}
+                                            @if ($user->isAdmin())
+                                                <span class="ml-2 inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">{{ __('Admin') }}</span>
+                                            @endif
+                                        </td>
+                                        <td class="px-6 py-4 text-sm text-zinc-600 dark:text-zinc-300">
+                                            {{ $user->email }}
+                                        </td>
+                                        <td class="px-6 py-4 text-center text-sm font-semibold text-sky-600 dark:text-sky-300">
+                                            {{ number_format($user->missions_count) }}
+                                        </td>
+                                        <td class="px-6 py-4 text-center text-sm font-semibold text-amber-600 dark:text-amber-300">
+                                            {{ number_format($user->task_lists_count) }}
+                                        </td>
+                                        <td class="px-6 py-4 text-right text-sm text-zinc-500 dark:text-zinc-400">
+                                            {{ $user->created_at->format('d/m/Y') }}
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
+                                            {{ __('Nenhum usuário cadastrado até o momento.') }}
+                                        </td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+@endsection

--- a/resources/views/app/shared/navigation.blade.php
+++ b/resources/views/app/shared/navigation.blade.php
@@ -2,30 +2,43 @@
 @php
     $items = [
         [
+            'label' => __('Dashboard'),
+            'href' => route('dashboard'),
+            'icon' => 'fa-solid fa-chart-line',
+            'active' => request()->routeIs('dashboard'),
+            'visible' => auth()->user()?->isAdmin(),
+        ],
+        [
             'label' => __('Tasks'),
             'href' => route('tasks.index'),
             'icon' => 'fa-solid fa-list-check',
             'active' => request()->routeIs('tasks.index'),
+            'visible' => true,
         ],
         [
             'label' => __('Pomodoro'),
             'href' => route('app.pomodoro'),
             'icon' => 'fa-solid fa-clock',
             'active' => request()->routeIs('app.pomodoro'),
+            'visible' => true,
         ],
         [
             'label' => __('Profile'),
             'href' => route('profile'),
             'icon' => 'fa-solid fa-user',
             'active' => request()->routeIs('profile'),
+            'visible' => true,
         ],
         [
             'label' => __('Configurações'),
             'href' => route('app.settings'),
             'icon' => 'fa-solid fa-gear',
             'active' => request()->routeIs('app.settings'),
+            'visible' => true,
         ],
     ];
+
+    $items = array_values(array_filter($items, fn ($item) => $item['visible'] ?? false));
 @endphp
 
 <aside class="hidden w-64 shrink-0 border-r border-zinc-200 bg-white px-4 py-6 dark:border-zinc-700 dark:bg-zinc-900 lg:block">

--- a/resources/views/auth_breeze/layout.blade.php
+++ b/resources/views/auth_breeze/layout.blade.php
@@ -7,7 +7,9 @@
 
         <title>{{ trim($__env->yieldContent('title', config('app.name', 'TaskInfinity'))) }}</title>
 
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @unless (app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endunless
         @livewireStyles
     </head>
     <body class="min-h-full bg-gradient-to-br from-zinc-100 via-white to-zinc-200 font-sans antialiased text-zinc-900">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,7 +7,9 @@
 
         <title>{{ trim($__env->yieldContent('title', config('app.name', 'TaskInfinity'))) }}</title>
 
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @unless (app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endunless
         @stack('styles')
         @livewireStyles
     </head>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -14,7 +14,9 @@
         <script src="https://kit.fontawesome.com/c9cfb44e99.js" crossorigin="anonymous"></script>
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @unless (app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endunless
         @livewireStyles
     </head>
     <body class="">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
 
         <!-- Styles -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @unless (app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endunless
     </head>
     <body class="antialiased font-sans">
         <div class="bg-gray-50 text-black/50 dark:bg-black dark:text-white/50">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 // This routes file registers HTTP endpoints for the web section.
+use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Ai\AiRequestController;
 use App\Http\Controllers\Economy\EconomyWalletController;
 use App\Http\Controllers\Gamification\AbilityController;
@@ -44,9 +45,10 @@ use Laravel\Pulse\Facades\Pulse;
 Route::view('/', 'welcome');
 Route::view('/teste', 'teste');
 
-Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified'])
-    ->name('dashboard');
+Route::middleware(['auth', 'verified', 'admin'])->group(function () {
+    Route::get('dashboard', DashboardController::class)
+        ->name('dashboard');
+});
 
 Route::view('profile', 'profile')
     ->middleware(['auth'])

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -38,14 +38,14 @@ it('rejects invalid credentials', function () {
     $this->assertGuest();
 });
 
-it('displays the navigation shell for authenticated users', function () {
-    $user = User::factory()->create();
+it('displays the navigation shell for admin users', function () {
+    $admin = User::factory()->admin()->create();
 
-    $response = $this->actingAs($user)->get('/dashboard');
+    $response = $this->actingAs($admin)->get('/dashboard');
 
     $response
         ->assertOk()
-        ->assertSeeText(__('Dashboard'))
+        ->assertSeeText(__('Admin Dashboard'))
         ->assertSeeText(__('Tasks'));
 });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -7,10 +7,25 @@ test('guests are redirected to the login page', function () {
     $response->assertRedirect(route('login'));
 });
 
-test('authenticated users can visit the dashboard', function () {
+test('non admin users cannot access the dashboard', function () {
     $user = User::factory()->create();
+
     $this->actingAs($user);
 
     $response = $this->get(route('dashboard'));
-    $response->assertStatus(200);
+
+    $response->assertForbidden();
+});
+
+test('admins can visit the dashboard', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin);
+
+    $response = $this->get(route('dashboard'));
+
+    $response
+        ->assertOk()
+        ->assertSeeText(__('Admin Dashboard'))
+        ->assertSeeText(__('Usuários cadastrados'));
 });


### PR DESCRIPTION
## Summary
- add an admin dashboard with statistics on users, missions, and lists
- protect the dashboard behind a new admin middleware and role column on users
- expose the admin link in navigation and tweak layouts to skip Vite assets during tests

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68de99c7d534832cb3810c05af5bfce3