### PR TITLE
Fix modal handling and shortcuts in task workspace

### DIFF
--- a/app/Livewire/Layout/ModalStack.php
+++ b/app/Livewire/Layout/ModalStack.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Livewire\Layout;
+
+use Illuminate\Support\Str;
+use Livewire\Component;
+
+class ModalStack extends Component
+{
+    protected $listeners = [
+        'openModal' => 'open',
+        'closeModal' => 'close',
+    ];
+
+    /**
+     * @var array<int, array{key:string, component:string, parameters:array}>
+     */
+    public array $modals = [];
+
+    public function open(string $component, array $arguments = []): void
+    {
+        $this->modals[] = [
+            'key' => (string) Str::uuid(),
+            'component' => $component,
+            'parameters' => $arguments,
+        ];
+    }
+
+    public function close(?string $key = null): void
+    {
+        if ($key) {
+            $this->modals = array_values(array_filter(
+                $this->modals,
+                fn (array $modal) => $modal['key'] !== $key
+            ));
+
+            return;
+        }
+
+        array_pop($this->modals);
+    }
+
+    public function render()
+    {
+        return view('livewire.layout.modal-stack');
+    }
+}

--- a/app/Livewire/Tasks/Modals/SubtaskEditor.php
+++ b/app/Livewire/Tasks/Modals/SubtaskEditor.php
@@ -28,11 +28,14 @@ class SubtaskEditor extends Component
 
     public int $maxSubtasks;
 
-    public function mount(int $missionId, ?int $parentId = null): void
+    public ?string $modalKey = null;
+
+    public function mount(int $missionId, ?int $parentId = null, ?string $modalKey = null): void
     {
         $this->missionId = $missionId;
         $this->parentId = $parentId;
         $this->maxSubtasks = MainPanel::MAX_SUBTASKS;
+        $this->modalKey = $modalKey;
 
         $this->hydrateParents();
     }
@@ -46,6 +49,11 @@ class SubtaskEditor extends Component
     {
         $this->open = false;
         $this->dispatch('subtask-editor-closed');
+        if ($this->modalKey) {
+            $this->dispatch('closeModal', $this->modalKey);
+        } else {
+            $this->dispatch('closeModal');
+        }
     }
 
     public function save(): void
@@ -104,10 +112,9 @@ class SubtaskEditor extends Component
 
         $this->notification()->success('Subtarefa criada', 'A subtarefa foi adicionada com sucesso.');
 
-        $this->closeModal();
-
         $this->dispatch('tasks-updated');
         $this->dispatch('task-selected', $mission->id, $checkpoint->id);
+        $this->closeModal();
     }
 
     private function hydrateParents(): void

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 @import './pomodoro.css';
 
 :root {
@@ -28,7 +29,7 @@ body {
     margin: 0;
     background: var(--bg);
     color: var(--text);
-    font: 14px/1.4 "Inter", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
+    font: 14px/1.4 "Roboto", system-ui, -apple-system, "Segoe UI", "Inter", Ubuntu,
         Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji",
         "Segoe UI Emoji";
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1155,6 +1155,108 @@ function setupDetailsKeyboard() {
   });
 }
 
+function shouldIgnoreHotkey(event) {
+  const target = event?.target;
+  if (!target) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  return (
+    target.isContentEditable === true ||
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT'
+  );
+}
+
+function focusNewTaskInput() {
+  const input = document.querySelector('.main .add-input');
+  if (!input) {
+    return false;
+  }
+
+  if (typeof input.focus === 'function') {
+    input.focus({ preventScroll: false });
+  }
+
+  return true;
+}
+
+function callSidebarAction(method, ...args) {
+  const sidebarRoot = document.querySelector('.sidebar');
+  const component = findLivewireComponent(sidebarRoot);
+  if (!component) {
+    return false;
+  }
+
+  component.call(method, ...args);
+
+  return true;
+}
+
+function callDetailsAction(method, ...args) {
+  const detailsRoot = document.querySelector('.ti-details');
+  const component = findLivewireComponent(detailsRoot);
+  if (!component) {
+    return false;
+  }
+
+  component.call(method, ...args);
+
+  return true;
+}
+
+function setupTaskHotkeys() {
+  if (document.__ti_hotkeys_wired) return;
+  document.__ti_hotkeys_wired = true;
+
+  const hasTasksLayout = () => document.querySelector('.app .main');
+
+  hotkeys('n', (event) => {
+    if (!hasTasksLayout() || shouldIgnoreHotkey(event)) {
+      return;
+    }
+
+    if (focusNewTaskInput()) {
+      event.preventDefault();
+    }
+  });
+
+  hotkeys('shift+l,ctrl+shift+l', (event) => {
+    if (!hasTasksLayout() || shouldIgnoreHotkey(event)) {
+      return;
+    }
+
+    const handled = callSidebarAction('openCreateModal', 'list');
+    if (handled) {
+      event.preventDefault();
+    }
+  });
+
+  hotkeys('shift+t,ctrl+shift+t', (event) => {
+    if (!hasTasksLayout() || shouldIgnoreHotkey(event)) {
+      return;
+    }
+
+    const handled = callSidebarAction('openTagModal');
+    if (handled) {
+      event.preventDefault();
+    }
+  });
+
+  hotkeys('shift+s,ctrl+shift+s', (event) => {
+    if (!hasTasksLayout() || shouldIgnoreHotkey(event)) {
+      return;
+    }
+
+    const handled = callDetailsAction('openSubtaskForm');
+    if (handled) {
+      event.preventDefault();
+    }
+  });
+}
+
 /* ────────────────────────────────────────────────────────────────── */
 /* BOOT: DOM pronto                                                   */
 /* ────────────────────────────────────────────────────────────────── */
@@ -1169,6 +1271,7 @@ function boot(root = document) {
   setupSortableSubtasks(root);
   setupFocusListeners();
   setupDetailsKeyboard();
+  setupTaskHotkeys();
 }
 
 window.tiBoot = boot;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,6 +26,8 @@
             @endif
         </div>
 
+        <livewire:layout.modal-stack />
+
         @stack('modals')
         @livewireScripts
         @stack('scripts')

--- a/resources/views/livewire/layout/modal-stack.blade.php
+++ b/resources/views/livewire/layout/modal-stack.blade.php
@@ -1,0 +1,8 @@
+<div>
+    @foreach ($modals as $modal)
+        @php
+            $parameters = array_merge($modal['parameters'] ?? [], ['modalKey' => $modal['key']]);
+        @endphp
+        @livewire($modal['component'], $parameters, key('modal-stack-' . $modal['key']))
+    @endforeach
+</div>

--- a/resources/views/livewire/tasks/modals/subtask-editor.blade.php
+++ b/resources/views/livewire/tasks/modals/subtask-editor.blade.php
@@ -1,58 +1,60 @@
-@if ($open)
-    <div class="ti-modal-backdrop" wire:click="closeModal">
-        <div class="ti-modal" wire:click.stop>
-            <form class="ti-modal-form" wire:submit.prevent="save">
-                <header class="ti-modal-header">
-                    <div>
-                        <h3>Nova subtarefa</h3>
-                        <p>Crie uma subtarefa para organizar melhor sua tarefa principal.</p>
-                    </div>
-                    <button class="ti-modal-close" type="button" wire:click="closeModal">
-                        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
-                        <span class="sr-only">Fechar</span>
-                    </button>
-                </header>
+<div>
+    @if ($open)
+        <div class="ti-modal-backdrop" wire:click="closeModal">
+            <div class="ti-modal" wire:click.stop>
+                <form class="ti-modal-form" wire:submit.prevent="save">
+                    <header class="ti-modal-header">
+                        <div>
+                            <h3>Nova subtarefa</h3>
+                            <p>Crie uma subtarefa para organizar melhor sua tarefa principal.</p>
+                        </div>
+                        <button class="ti-modal-close" type="button" wire:click="closeModal">
+                            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                            <span class="sr-only">Fechar</span>
+                        </button>
+                    </header>
 
-                <div class="ti-modal-body">
-                    <div class="ti-modal-row">
-                        <label class="ti-modal-label" for="subtask-title">Título</label>
-                        <input
-                            id="subtask-title"
-                            type="text"
-                            class="ti-modal-control"
-                            placeholder="Descreva a subtarefa"
-                            wire:model.defer="title"
-                            autofocus
-                        />
-                        @error('title')
-                            <p class="ti-modal-error">{{ $message }}</p>
-                        @enderror
+                    <div class="ti-modal-body">
+                        <div class="ti-modal-row">
+                            <label class="ti-modal-label" for="subtask-title">Título</label>
+                            <input
+                                id="subtask-title"
+                                type="text"
+                                class="ti-modal-control"
+                                placeholder="Descreva a subtarefa"
+                                wire:model.defer="title"
+                                autofocus
+                            />
+                            @error('title')
+                                <p class="ti-modal-error">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div class="ti-modal-row">
+                            <label class="ti-modal-label" for="subtask-parent">Adicionar dentro de</label>
+                            <select
+                                id="subtask-parent"
+                                class="ti-modal-control"
+                                wire:model="parentId"
+                            >
+                                <option value="">Sem pai (nível raiz)</option>
+                                @foreach ($parentOptions as $id => $label)
+                                    <option value="{{ $id }}">{{ $label }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="ti-modal-hint">
+                            Você pode criar até {{ $maxSubtasks }} subtarefas por nível.
+                        </div>
                     </div>
 
-                    <div class="ti-modal-row">
-                        <label class="ti-modal-label" for="subtask-parent">Adicionar dentro de</label>
-                        <select
-                            id="subtask-parent"
-                            class="ti-modal-control"
-                            wire:model="parentId"
-                        >
-                            <option value="">Sem pai (nível raiz)</option>
-                            @foreach ($parentOptions as $id => $label)
-                                <option value="{{ $id }}">{{ $label }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-
-                    <div class="ti-modal-hint">
-                        Você pode criar até {{ $maxSubtasks }} subtarefas por nível.
-                    </div>
-                </div>
-
-                <footer class="ti-modal-footer">
-                    <button type="button" class="ghost" wire:click="closeModal">Cancelar</button>
-                    <button type="submit" class="primary">Adicionar</button>
-                </footer>
-            </form>
+                    <footer class="ti-modal-footer">
+                        <button type="button" class="ghost" wire:click="closeModal">Cancelar</button>
+                        <button type="submit" class="primary">Adicionar</button>
+                    </footer>
+                </form>
+            </div>
         </div>
-    </div>
-@endif
+    @endif
+</div>

--- a/tests/Feature/Tasks/TaskInteractionsTest.php
+++ b/tests/Feature/Tasks/TaskInteractionsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Tasks\MainPanel;
+use App\Livewire\Tasks\Modals\SubtaskEditor;
+use App\Livewire\Tasks\Sidebar;
+use App\Models\Mission;
+use App\Models\TaskList;
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
+
+test('user can create a list from the sidebar modal', function () {
+    Config::set('scout.driver', 'database');
+    Config::set('scout.queue', false);
+    Config::set('scout.after_commit', false);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test(Sidebar::class)
+        ->call('openCreateModal', 'list')
+        ->set('newListName', 'Planejamento')
+        ->call('saveList');
+
+    $this->assertDatabaseHas('lists', [
+        'user_id' => $user->id,
+        'name' => 'Planejamento',
+    ]);
+});
+
+test('user can create a tag from the sidebar', function () {
+    Config::set('scout.driver', 'database');
+    Config::set('scout.queue', false);
+    Config::set('scout.after_commit', false);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test(Sidebar::class)
+        ->call('openTagModal')
+        ->set('newTagName', 'Urgente')
+        ->call('createTag');
+
+    $this->assertDatabaseHas('tags', [
+        'user_id' => $user->id,
+        'name' => 'Urgente',
+    ]);
+});
+
+test('user can add a task inside a list', function () {
+    Config::set('scout.driver', 'database');
+    Config::set('scout.queue', false);
+    Config::set('scout.after_commit', false);
+
+    $user = User::factory()->create();
+    $list = TaskList::create([
+        'user_id' => $user->id,
+        'name' => 'Inbox',
+        'position' => 1,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(MainPanel::class, ['currentListId' => $list->id])
+        ->set('newTaskTitle', 'Comprar café')
+        ->call('createTask');
+
+    $this->assertDatabaseHas('missions', [
+        'user_id' => $user->id,
+        'list_id' => $list->id,
+        'title' => 'Comprar café',
+    ]);
+});
+
+test('subtask editor saves checkpoints and closes the modal', function () {
+    Config::set('scout.driver', 'database');
+    Config::set('scout.queue', false);
+    Config::set('scout.after_commit', false);
+
+    $user = User::factory()->create();
+    $list = TaskList::create([
+        'user_id' => $user->id,
+        'name' => 'Trabalho',
+        'position' => 1,
+    ]);
+
+    $mission = Mission::create([
+        'user_id' => $user->id,
+        'list_id' => $list->id,
+        'title' => 'Preparar apresentação',
+        'status' => 'active',
+        'position' => 1,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(SubtaskEditor::class, [
+        'missionId' => $mission->id,
+        'parentId' => null,
+        'modalKey' => 'modal-key-test',
+    ])
+        ->set('title', 'Definir roteiro')
+        ->call('save')
+        ->assertSet('open', false)
+        ->assertDispatched('closeModal', 'modal-key-test');
+
+    $this->assertDatabaseHas('checkpoints', [
+        'mission_id' => $mission->id,
+        'title' => 'Definir roteiro',
+    ]);
+});


### PR DESCRIPTION
## Summary
- introduce a Livewire modal stack and update the subtask editor so modals open and close reliably
- wire new keyboard shortcuts for creating lists, tags, subtasks, and focusing the quick add input on the tasks board
- switch the UI font to Roboto and add regression tests for creating lists, tags, tasks, and subtasks

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68deaf6b96c0832c910adb7bee882d08